### PR TITLE
Ocrd forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,15 +52,15 @@
 [submodule "ocrd_im6convert"]
 	path = ocrd_im6convert
 	url = https://github.com/OCR-D/ocrd_im6convert.git
-[submodule "OCR-D-LAYoutERkennung"]
-	path = OCR-D-LAYoutERkennung
-	url = https://github.com/mjenckel/OCR-D-LAYoutERkennung.git
+[submodule "ocrd_anybaseocr"]
+	path = ocrd_anybaseocr
+	url = https://github.com/OCR-D/ocrd_anybaseocr.git
 [submodule "segmentation-runner"]
 	path = segmentation-runner
 	url = https://github.com/ocr-d-modul-2-segmentierung/segmentation-runner.git
 [submodule "ocrd_typegroups_classifier"]
 	path = ocrd_typegroups_classifier
-	url = https://github.com/seuretm/ocrd_typegroups_classifier.git
+	url = https://github.com/OCR-D/ocrd_typegroups_classifier.git
 [submodule "opencv-python"]
 	path = opencv-python
 	url = https://github.com/skvark/opencv-python.git

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-textline
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-layout-analysis
 OCRD_ANYBASEOCR += $(BIN)/ocrd-anybaseocr-block-segmentation
 
-$(OCRD_ANYBASEOCR): OCR-D-LAYoutERkennung
+$(OCRD_ANYBASEOCR): ocrd_anybaseocr
 
 OCRD_EXECUTABLES += $(OCRD_TYPECLASS)
 
@@ -267,7 +267,7 @@ $(OCRD_EXECUTABLES): | $(BIN)/wheel
 .PHONY: fix-pip
 # temporary workaround for conflicting requirements between modules:
 # - opencv-python instead of opencv-python-headless (which needs X11 libs)
-#   (pulled by OCR-D-LAYoutERkennung and segmentation-runner)
+#   (pulled by ocrd_anybaseocr and segmentation-runner)
 # - tensorflow>=2.0, tensorflow_gpu in another version
 # - pillow==5.4.1 instead of >=6.2
 fix-pip:


### PR DESCRIPTION
Use OCR-D forks of LAYoutERkennung and typegroups_classifier. We publish PyPI packages from them and they allow us more rapid development.

(this can wait until repo transfer)